### PR TITLE
chore: switched from exa to eza

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This will install only newer version of packages.
 
 | Cli app        | Rust app                                                | Description                              |
 |----------------|---------------------------------------------------------|------------------------------------------|
-| ls             | [exa](https://github.com/ogham/exa)                     | List content(files/dirs) in dir          |
+| ls             | [eza](https://github.com/eza-community/eza)             | List content(files/dirs) in dir          |
 | cd             | [zoxide](https://github.com/ajeetdsouza/zoxide)         | Changes the current directory.           |
 | sed            | [sd](https://github.com/chmln/sd)                       | Text stream editor.                      |
 | vim            | [amp](https://github.com/jmacdonald/amp)                | Text editor.                             |

--- a/RustyLinux.sh
+++ b/RustyLinux.sh
@@ -9,7 +9,7 @@ rustup update
 
 # CLI
 # exa - ls
-cargo install exa
+cargo install eza
 
 # zoxide - cd
 cargo install zoxide


### PR DESCRIPTION
Since [`exa`](https://github.com/ogham/exa) seems to be not maintained anymore, I switched to its successor [`eza`](https://github.com/eza-community/eza) 