### PR TITLE
feat: added a GitHub action to test the install script

### DIFF
--- a/.github/workflows/test_rusty_linux.yml
+++ b/.github/workflows/test_rusty_linux.yml
@@ -16,10 +16,6 @@ jobs:
             toolchain: stable
             override: true
             components: rustfmt, clippy
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
       - name: Install Rusty Linux
         run: chmod a+x ./RustyLinux.sh && ./RustyLinux.sh
         

--- a/.github/workflows/test_rusty_linux.yml
+++ b/.github/workflows/test_rusty_linux.yml
@@ -4,7 +4,10 @@ on: [push]
 jobs:
   check:
     name: Rusty Linux
-    runs-on: [ubuntu-24.04, ubuntu-24.04-arm]
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Install latest stable

--- a/.github/workflows/test_rusty_linux.yml
+++ b/.github/workflows/test_rusty_linux.yml
@@ -1,0 +1,22 @@
+name: Test Rusty Linux
+
+on: [push]
+jobs:
+  check:
+    name: Rusty Linux
+    runs-on: [ubuntu-24.04, ubuntu-24.04-arm]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            override: true
+            components: rustfmt, clippy
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+      - name: Install Rusty Linux
+        run: chmod a+x ./RustyLinux.sh && ./RustyLinux.sh
+        

--- a/RustyLinux.sh
+++ b/RustyLinux.sh
@@ -115,3 +115,5 @@ flatpak install flathub io.bassi.Amberol
 cargo install fyrox
 
 # DE - cosmic-epoch - instruction currently not available
+
+exit 0


### PR DESCRIPTION
I added a GitHub action to run the install script for testing purposes on push.

It's a long running process, because there are a lot of files to compile. It's possible to speed up the install process. 

If you think this is useful, feel free to merge.

But you should merge #18 before this, because there is a typo in the install script and it will probably fail. 